### PR TITLE
Update to GNOME Platform version 44

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Add Flathub repository
       run: sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
     - name: Install GNOME SDK & Platform
-      run: sudo flatpak install org.gnome.Sdk//43 org.gnome.Platform//43 -y
+      run: sudo flatpak install org.gnome.Sdk//43 org.gnome.Platform//44 -y
     - name: Build
       run: dev-scripts/build.sh

--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Add Flathub repository
       run: sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
     - name: Install GNOME SDK & Platform
-      run: sudo flatpak install org.gnome.Sdk//43 org.gnome.Platform//44 -y
+      run: sudo flatpak install org.gnome.Sdk//44 org.gnome.Platform//44 -y
     - name: Build
       run: dev-scripts/build.sh

--- a/com.github.Darazaki.Spedread.json
+++ b/com.github.Darazaki.Spedread.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.Darazaki.Spedread",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "spedread",
     "finish-args": [

--- a/src/SpedreadWindow.vala
+++ b/src/SpedreadWindow.vala
@@ -426,18 +426,18 @@ class SpedreadWindow : Gtk.ApplicationWindow {
                        GLib.SettingsBindFlags.GET
         );
 
-        var use_libadwaita = new Gtk.Switch () {
+        var use_libadwaita = new Gtk.CheckButton () {
             halign = Gtk.Align.END,
         };
         settings.bind ("use-libadwaita",
-                       use_libadwaita, "state",
+                       use_libadwaita, "active",
                        GLib.SettingsBindFlags.DEFAULT
         );
-        use_libadwaita.state_set.connect (new_state => {
+        use_libadwaita.toggled.connect (new_state => {
             // Warn the user that the change will only be applied after an app
             // restart. `is_active` is there to make sure only the focused
             // window displays the warning
-            if (is_active && new_state != SpedreadSettings.is_using_libadwaita) {
+            if (is_active && new_state.get_active () != SpedreadSettings.is_using_libadwaita) {
                 popover.popdown ();
 
                 var message_string = _ (
@@ -456,7 +456,7 @@ class SpedreadWindow : Gtk.ApplicationWindow {
             }
 
             // Set the state (see `Gtk.Switch.state_set`)
-            return false;
+            return;
         });
 
         var about_button = new Gtk.Button.with_label (_ ("About Spedread..."));

--- a/src/SpedreadWindow.vala
+++ b/src/SpedreadWindow.vala
@@ -426,18 +426,18 @@ class SpedreadWindow : Gtk.ApplicationWindow {
                        GLib.SettingsBindFlags.GET
         );
 
-        var use_libadwaita = new Gtk.CheckButton () {
+        var use_libadwaita = new Gtk.Switch () {
             halign = Gtk.Align.END,
         };
         settings.bind ("use-libadwaita",
                        use_libadwaita, "active",
                        GLib.SettingsBindFlags.DEFAULT
         );
-        use_libadwaita.toggled.connect (new_state => {
+        use_libadwaita.state_set.connect (new_state => {
             // Warn the user that the change will only be applied after an app
             // restart. `is_active` is there to make sure only the focused
             // window displays the warning
-            if (is_active && new_state.get_active () != SpedreadSettings.is_using_libadwaita) {
+            if (is_active && new_state != SpedreadSettings.is_using_libadwaita) {
                 popover.popdown ();
 
                 var message_string = _ (
@@ -456,7 +456,7 @@ class SpedreadWindow : Gtk.ApplicationWindow {
             }
 
             // Set the state (see `Gtk.Switch.state_set`)
-            return;
+            return false;
         });
 
         var about_button = new Gtk.Button.with_label (_ ("About Spedread..."));


### PR DESCRIPTION
Hello!
When I ran the application on a new platform, I noticed that the switch to use libadwaita incorrectly displayed its active position. It needs to be toggled twice before it changes its state.