### PR TITLE
feature - vertical scroll in read tab to go to next or previous

### DIFF
--- a/src/ReadTab.vala
+++ b/src/ReadTab.vala
@@ -133,6 +133,17 @@ class Spedread.ReadTab : Gtk.Grid {
         attach (_next, 2, 1, 1, 1);
     }
 
+    var scroll_controller = new Gtk.EventControllerScroll (Gtk.EventControllerScrollFlags.VERTICAL);
+    scroll_controller.scroll.connect ((_, dy) => {
+        if (dy > 0)
+            next_word ();
+        else if (dy < 0)
+            previous_word ();
+        return true;
+    });
+    add_controller (scroll_controller);
+}
+
     /** Focus the play button so that the space key plays/pauses */
     public void focus_play_button () {
         _play.grab_focus ();

--- a/src/ReadTab.vala
+++ b/src/ReadTab.vala
@@ -131,18 +131,19 @@ class Spedread.ReadTab : Gtk.Grid {
         attach (_previous, 0, 1, 1, 1);
         attach (_play, 1, 1, 1, 1);
         attach (_next, 2, 1, 1, 1);
-    }
 
-    var scroll_controller = new Gtk.EventControllerScroll (Gtk.EventControllerScrollFlags.VERTICAL);
-    scroll_controller.scroll.connect ((_, dy) => {
-        if (dy > 0)
-            next_word ();
-        else if (dy < 0)
-            previous_word ();
-        return true;
-    });
-    add_controller (scroll_controller);
-}
+        var scroll_controller = new Gtk.EventControllerScroll (
+            Gtk.EventControllerScrollFlags.VERTICAL | Gtk.EventControllerScrollFlags.DISCRETE
+        );
+        scroll_controller.scroll.connect ((_, dy) => {
+            if (dy > 0)
+                next_word ();
+            else if (dy < 0)
+                previous_word ();
+            return true;
+        });
+        add_controller (scroll_controller);
+    }
 
     /** Focus the play button so that the space key plays/pauses */
     public void focus_play_button () {


### PR DESCRIPTION
i just did a small adition of gtk handler/controller to the read tab builder to handle vertical scroll. tested it on mouse with one scroll wheel and on touchpad and works as i would expect.